### PR TITLE
Clean output (with verbosity levels)

### DIFF
--- a/CalculateHoldings.py
+++ b/CalculateHoldings.py
@@ -4,7 +4,6 @@ from FactorFunction import Factors, Momentum6m, ROE, ROA
 from portfolio import Portfolio
 import pandas as pd
 import numpy as np
-
 def calculate_holdings(factor, aum, market):
     # Factor values for all tickers in the market
     factor_values = {ticker: factor.get(ticker, market) for ticker in market.stocks['Ticker']}
@@ -30,7 +29,7 @@ def calculate_holdings(factor, aum, market):
 
     return portfolio_new
 
-def calculate_growth(portfolio, next_market, current_market):
+def calculate_growth(portfolio, next_market, current_market, verbosity=verbosity_level):
     # Calculate start value using the current market
     total_start_value = 0
     for factor_portfolio in portfolio:
@@ -43,45 +42,47 @@ def calculate_growth(portfolio, next_market, current_market):
             ticker = inv["ticker"]
             end_price = next_market.getPrice(ticker)
             if end_price is not None:
-                # Use next year's price for growth calculation
                 total_end_value += inv["number_of_shares"] * end_price
             else:
-                # Stock missing in next market, liquidate at entry price
                 entry_price = current_market.getPrice(ticker)
                 if entry_price is not None:
                     total_end_value += inv["number_of_shares"] * entry_price
-                    print(f"{ticker} - Missing in {next_market.t}, liquidating at entry price: {entry_price}")
+                    if verbosity == 3:
+                        print(f"{ticker} - Missing in {next_market.t}, liquidating at entry price: {entry_price}")
 
     # Calculate growth
     growth = (total_end_value - total_start_value) / total_start_value if total_start_value else 0
     return growth, total_start_value, total_end_value
 
-def rebalance_portfolio(data, factors, start_year, end_year, initial_aum):
+def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbosity=verbosity_level):
     aum = initial_aum
     years = []
     portfolio_returns = []  # Store yearly returns for Information Ratio
     benchmark_returns = []  # Store benchmark returns for comparison
 
     for year in range(start_year, end_year):
-        print(f"\nRebalancing Portfolio for {year} based on factors...")
+
         market = MarketObject(data.loc[data['Year'] == year], year)
-        
         yearly_portfolio = []
+
         for factor in factors:
             factor_portfolio = calculate_holdings(
-            factor=factor,
-            aum=aum / len(factors),
-            market=market
+                factor=factor,
+                aum=aum / len(factors),
+                market=market
             )
             yearly_portfolio.append(factor_portfolio)
-        
+
         if year < end_year:
             next_market = MarketObject(data.loc[data['Year'] == year + 1], year + 1)
-            growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, next_market, market)
-            
-            print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
+            growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, next_market, market, verbosity)
+
+            if verbosity >= 2:
+                print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, "
+                      f"Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
+
             aum = total_end_value  # Liquidate and reinvest
-            
+
             # Append annual return (growth) to portfolio_returns
             portfolio_returns.append(growth)
 
@@ -91,11 +92,22 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum):
 
         years.append(year)
 
-    # Calculate overall growth
-    overall_growth = (aum - initial_aum) / initial_aum if initial_aum else 0
-    print(f"\nFinal Portfolio Value after {end_year}: ${aum:.2f}")
-    print(f"Overall Growth from {start_year} to {end_year}: {overall_growth * 100:.2f}%")
-    
+    if verbosity >= 1:
+        print("\n==== Final Summary ====")
+        print(f"Initial Portfolio Value: ${initial_aum:.2f}")
+        # Calculate overall growth
+        overall_growth = (aum - initial_aum) / initial_aum if initial_aum else 0
+        print(f"Final Portfolio Value after {end_year}: ${aum:.2f}")
+        print(f"Overall Growth from {start_year} to {end_year}: {overall_growth * 100:.2f}%")
+        information_ratio = calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity)
+    return {
+        'final_value': aum,
+        'yearly_returns': portfolio_returns,
+        'benchmark_returns': benchmark_returns,
+        'years': years
+    }
+
+
     # Calculate and print Information Ratio
     information_ratio = calculate_information_ratio(portfolio_returns, benchmark_returns)
     if information_ratio is not None:
@@ -118,7 +130,7 @@ def get_benchmark_return(year):
     }
     return benchmark_data.get(year, 0)
 
-def calculate_information_ratio(portfolio_returns, benchmark_returns):
+def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity = verbosity_level):
     """
     Calculates the Information Ratio (IR) for a given set of portfolio returns and benchmark returns.
     
@@ -148,4 +160,8 @@ def calculate_information_ratio(portfolio_returns, benchmark_returns):
     
     # Compute Information Ratio
     information_ratio = mean_active_return / tracking_error
+    if verbosity >=1:
+        print(f"Information Ratio: {information_ratio:.4f}")
     return information_ratio
+   
+        

--- a/CalculateHoldings.py
+++ b/CalculateHoldings.py
@@ -54,7 +54,7 @@ def calculate_growth(portfolio, next_market, current_market, verbosity=None):
     growth = (total_end_value - total_start_value) / total_start_value if total_start_value else 0
     return growth, total_start_value, total_end_value
 
-def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbosity=verbosity_level):
+def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbosity=None):
     aum = initial_aum
     years = []
     portfolio_returns = []  # Store yearly returns for Information Ratio
@@ -130,7 +130,7 @@ def get_benchmark_return(year):
     }
     return benchmark_data.get(year, 0)
 
-def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity = verbosity_level):
+def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity = None):
     """
     Calculates the Information Ratio (IR) for a given set of portfolio returns and benchmark returns.
     

--- a/CalculateHoldings.py
+++ b/CalculateHoldings.py
@@ -29,7 +29,7 @@ def calculate_holdings(factor, aum, market):
 
     return portfolio_new
 
-def calculate_growth(portfolio, next_market, current_market, verbosity=verbosity_level):
+def calculate_growth(portfolio, next_market, current_market, verbosity=None):
     # Calculate start value using the current market
     total_start_value = 0
     for factor_portfolio in portfolio:

--- a/FactorFunction.py
+++ b/FactorFunction.py
@@ -1,6 +1,8 @@
 from MarketObject import MarketObject, load_data
 import pandas as pd
 
+load_data
+import numpy as np
 class Factors:
     def get(ticker, market):
         return "Factor not specified"
@@ -245,26 +247,26 @@ class NextYrActiveReturn(Factors):
             print(f"Error accessing Next-Year's Active Return % for {ticker}: {e}")
             return None
 
-#Creating an Example
-if __name__ == "__main__":
-    rdata = load_data()
-    rdata.columns = rdata.columns.str.strip()
-    rdata = rdata.loc[:, ~rdata.columns.duplicated(keep='first')]
-    rdata['Ticker'] = rdata['Ticker-Region'].dropna().apply(lambda x: x.split('-')[0].strip())
-    rdata['Date'] = pd.to_datetime(rdata['Date'])
-    rdata['Year'] = rdata['Date'].dt.year
+# #Creating an Example
+# if __name__ == "__main__":
+#     rdata = load_data()
+#     rdata.columns = rdata.columns.str.strip()
+#     rdata = rdata.loc[:, ~rdata.columns.duplicated(keep='first')]
+#     rdata['Ticker'] = rdata['Ticker-Region'].dropna().apply(lambda x: x.split('-')[0].strip())
+#     rdata['Date'] = pd.to_datetime(rdata['Date'])
+#     rdata['Year'] = rdata['Date'].dt.year
 
-    df_2002 = rdata[rdata['Year'] == 2002].copy()
-    df_2003 = rdata[rdata['Year'] == 2003].copy()
+#     df_2002 = rdata[rdata['Year'] == 2002].copy()
+#     df_2003 = rdata[rdata['Year'] == 2003].copy()
 
-    marketObject_2002 = MarketObject(df_2002, 2002)
-    marketObject_2003 = MarketObject(df_2003, 2003)
+#     marketObject_2002 = MarketObject(df_2002, 2002)
+#     marketObject_2003 = MarketObject(df_2003, 2003)
 
 
-    # EXAMPLE USING Factors CLASS 
-    Momentum6m_2002_FLWS = Factors.Momentum6m("FLWS", marketObject_2002)
-    Momentum6m_2002_AAPL = Factors.Momentum6m("AAPL", marketObject_2002)
+#     # EXAMPLE USING Factors CLASS 
+#     Momentum6m_2002_FLWS = Factors.Momentum6m("FLWS", marketObject_2002)
+#     Momentum6m_2002_AAPL = Factors.Momentum6m("AAPL", marketObject_2002)
 
-    print(f'\n6 Month Momentum Value of FLWS in 2002: ' + str(Momentum6m_2002_FLWS))
-    print(f'6 Month Momentum Value of AAPL in 2002: ' + str(Momentum6m_2002_AAPL))
+#     print(f'\n6 Month Momentum Value of FLWS in 2002: ' + str(Momentum6m_2002_FLWS))
+#     print(f'6 Month Momentum Value of AAPL in 2002: ' + str(Momentum6m_2002_AAPL))
 

--- a/MarketObject.py
+++ b/MarketObject.py
@@ -1,3 +1,6 @@
+###commenting this out to avoid conflicts in colab notebook - molly
+##from google.colab import drive
+##drive.mount('/content/drive')
 import pandas as pd
 import numpy as np
 ### CREATING FUNCTION TO LOAD DATA ###

--- a/MarketObject.py
+++ b/MarketObject.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 ### CREATING FUNCTION TO LOAD DATA ###
 def load_data():
-    file_path = 'C:\\Users\\FM\'s Laptop\\Downloads\\College\\SYSEN 5900-669\\Financial Portfoilio\\Clean output\\FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
+    file_path = '/content/drive/My Drive/Cayuga Fund Factor Lake/FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
     rdata = pd.read_excel(file_path, sheet_name='Data', header=2, skiprows=[3, 4])
     return rdata
 

--- a/MarketObject.py
+++ b/MarketObject.py
@@ -1,46 +1,48 @@
-###commenting this out to avoid conflicts in colab notebook - molly
-##from google.colab import drive
-##drive.mount('/content/drive')
 import pandas as pd
 import numpy as np
 ### CREATING FUNCTION TO LOAD DATA ###
 def load_data():
-    file_path = '/content/drive/My Drive/Cayuga Fund Factor Lake/FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
+    file_path = 'C:\\Users\\FM\'s Laptop\\Downloads\\College\\SYSEN 5900-669\\Financial Portfoilio\\Clean output\\FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
     rdata = pd.read_excel(file_path, sheet_name='Data', header=2, skiprows=[3, 4])
     return rdata
+
 class MarketObject():
-    def __init__(self, data, t):
+    def __init__(self, data, t, verbosity=1):
         """
-        data(Dataframe):    column 1 being 'Ticker', column 2 being 'Ending Price', column 3 being ''Year'', column 4 being 'ROE using 9/30 Data', column 5 being 'ROA using 9/30 Data', column 6 being ''6-Mo Momentum %'
-        t(Datetime):        Date of market data,
+        data(DataFrame): column 1 is 'Ticker', column 2 is 'Ending Price', column 3 is 'Year', column 4 is 'ROE using 9/30 Data', etc.
+        t (int): Year of market data.
+        verbosity (int): Controls level of printed output. 0 = silent, 1 = normal, 2+ = verbose.
         """
         data.columns = data.columns.str.strip()
         data = data.loc[:, ~data.columns.duplicated(keep='first')]
+
         if 'Ticker' not in data.columns and 'Ticker-Region' in data.columns:
             data['Ticker'] = data['Ticker-Region'].dropna().apply(lambda x: x.split('-')[0].strip())
         if 'Year' not in data.columns and 'Date' in data.columns:
             data['Date'] = pd.to_datetime(data['Date'])
             data['Year'] = data['Date'].dt.year
-        available_factors = ['ROE using 9/30 Data', 'ROA using 9/30 Data', '12-Mo Momentum %', '1-Mo Momentum %', 'Price to Book Using 9/30 Data', 'Next FY Earns/P', '1-Yr Price Vol %', 'Accruals/Assets', 'ROA %', '1-Yr Asset Growth %', '1-Yr CapEX Growth %', 'Book/Price', 'Next-Year\'s Return %', 'Next-Year\'s Active Return %']
+
+        available_factors = [
+            'ROE using 9/30 Data', 'ROA using 9/30 Data', '12-Mo Momentum %', '1-Mo Momentum %',
+            'Price to Book Using 9/30 Data', 'Next FY Earns/P', '1-Yr Price Vol %', 'Accruals/Assets',
+            'ROA %', '1-Yr Asset Growth %', '1-Yr CapEX Growth %', 'Book/Price',
+            "Next-Year's Return %", "Next-Year's Active Return %"
+        ]
+
         keep_cols = ['Ticker', 'Ending Price', 'Year', '6-Mo Momentum %'] + available_factors
         data = data[[col for col in keep_cols if col in data.columns]].copy()
+
+        # Replace '--' with NaNs
         data[['Ending Price'] + available_factors] = data[['Ending Price'] + available_factors].replace('--', None)
+
         self.stocks = data
         self.t = t
+        self.verbosity = verbosity
+
     def getPrice(self, ticker):
         ticker_data = self.stocks.loc[self.stocks['Ticker'] == ticker]
-        #check to see if results are empty - molly
         if ticker_data.empty:
-            print(f"{ticker} - not found in market data for {self.t} - SKIPPING")
+            if self.verbosity >= 2:
+                print(f"{ticker} - not found in market data for {self.t} - SKIPPING")
             return None
-        #if the data exists, return the last row's ending price - molly
         return ticker_data['Ending Price'].iloc[-1]
-### MOVED THIS TO PORTFOLIO.PY ###
-#data = rdata.copy()
-#data['Ticker'] = data['Ticker-Region'].dropna().apply(lambda x: x[0:x.find('-')])
-#data['Year'] = pd.to_datetime(data['Date']).dt.year
-#data = data[['Ticker', 'Ending Price', 'Year']]
-#marketObject_2002 = MarketObject(data.loc[data['Year'] == 2002], 2002)
-#marketObject_2003 = MarketObject(data.loc[data['Year'] == 2003], 2003)
-#print('price of AOS in 2002 = ' + str(marketObject_2002.getPrice('AOS')))
-#print('price of AOS in 2003 = ' + str(marketObject_2003.getPrice('AOS')))

--- a/UserInput.py
+++ b/UserInput.py
@@ -2,7 +2,7 @@ import FactorFunction
 
 def get_factors(available_factors):
     # Display the lists of available factors with index
-    print(f"Available factors: ")
+    print(f"\nAvailable factors: ")
     for i in range(len(available_factors)):
         print(f"{i + 1}. {available_factors[i]}")
     

--- a/VerbosityOptions.py
+++ b/VerbosityOptions.py
@@ -1,0 +1,22 @@
+VERBOSITY_OPTIONS = {
+    1: "Summary Only",
+    2: "Year-by-Year Results",
+    3: "Debug (Everything)"
+}
+
+def get_verbosity_level():
+    print("\nSelect output verbosity level:")
+    for key, value in VERBOSITY_OPTIONS.items():
+        print(f"{key}. {value}")
+    choice = input("Enter your choice (1-3): ")
+    try:
+        choice = int(choice)
+        if choice in VERBOSITY_OPTIONS:
+            print(f"\nVerbosity set to: {VERBOSITY_OPTIONS[choice]}")
+            return choice
+        else:
+            print("Invalid selection. Defaulting to Summary Only.")
+            return 1
+    except ValueError:
+        print("Invalid input, defaulting to Summary Only.")
+        return 1

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from portfolio import Portfolio
 from CalculateHoldings import rebalance_portfolio
 from UserInput import get_factors
 import pandas as pd
+import numpy as np
 
 def main():
     ### Load market data ###
@@ -16,10 +17,9 @@ def main():
     available_factors = ['ROE using 9/30 Data', 'ROA using 9/30 Data', '12-Mo Momentum %', '6-Mo Momentum %', '1-Mo Momentum %', 'Price to Book Using 9/30 Data', 'Next FY Earns/P', '1-Yr Price Vol %', 'Accruals/Assets', 'ROA %', '1-Yr Asset Growth %', '1-Yr CapEX Growth %', 'Book/Price', 'Next-Year\'s Return %', 'Next-Year\'s Active Return %']
     rdata = rdata[['Ticker', 'Ending Price', 'Year'] + available_factors]
     factors = get_factors(available_factors)
-
+    verbosity_level = get_verbosity_level() 
     ### Rebalancing portfolio across years ###
-    print("Rebalancing portfolio...")
-    final_portfolio = rebalance_portfolio(rdata, factors, start_year=2002, end_year=2023, initial_aum=1)
-
+    print("\nRebalancing portfolio...")
+    final_portfolio = rebalance_portfolio(rdata, factors, start_year=2002, end_year=2023, initial_aum=1,verbosity=verbosity_level)
 if __name__ == "__main__":
     main()

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from MarketObject import load_data, MarketObject
 from portfolio import Portfolio
 from CalculateHoldings import rebalance_portfolio
 from UserInput import get_factors
+from VerbosityOptions import get_verbosity_level
 import pandas as pd
 import numpy as np
 


### PR DESCRIPTION
### Added verbosity_level as a configurable global or script parameter

**Controlled log detail through verbosity levels:**

- Level 1: Summary stats only

- Level 2: Annual performance breakdown

- Level 3: Detailed liquidation logs for missing tickers

**Ensured cleaner console output and improved debugging capability**

**Updated CalculateHoldings (calculate_growth, rebalance_portfolio, calculate_information_ratio), main, and market object to use verbosity levels.**