### PR TITLE
Sector restriction

### DIFF
--- a/UnitTests/test_known_good.py
+++ b/UnitTests/test_known_good.py
@@ -18,7 +18,7 @@ class TestFactorLakePortfolio(unittest.TestCase):
 
     def test_portfolio_growth(self):
         portfolio_values = rebalance_portfolio(self.data, self.factors, self.start_year, self.end_year, self.initial_aum)
-        final_aum = portfolio_values['final_value']]
+        final_aum = portfolio_values['final_value']
 
         self.assertAlmostEqual(
             final_aum,

--- a/UnitTests/test_known_good.py
+++ b/UnitTests/test_known_good.py
@@ -18,7 +18,7 @@ class TestFactorLakePortfolio(unittest.TestCase):
 
     def test_portfolio_growth(self):
         portfolio_values = rebalance_portfolio(self.data, self.factors, self.start_year, self.end_year, self.initial_aum)
-        final_aum = portfolio_values[-1]
+        final_aum = portfolio_values['final_value']]
 
         self.assertAlmostEqual(
             final_aum,

--- a/UnitTests/test_multiple_factors.py
+++ b/UnitTests/test_multiple_factors.py
@@ -18,7 +18,7 @@ class TestFactorLakePortfolio(unittest.TestCase):
 
     def test_portfolio_growth(self):
         portfolio_values = rebalance_portfolio(self.data, self.factors, self.start_year, self.end_year, self.initial_aum)
-        final_aum = portfolio_values['final_value']]
+        final_aum = portfolio_values['final_value']
 
         self.assertAlmostEqual(
             final_aum,

--- a/UnitTests/test_multiple_factors.py
+++ b/UnitTests/test_multiple_factors.py
@@ -18,7 +18,7 @@ class TestFactorLakePortfolio(unittest.TestCase):
 
     def test_portfolio_growth(self):
         portfolio_values = rebalance_portfolio(self.data, self.factors, self.start_year, self.end_year, self.initial_aum)
-        final_aum = portfolio_values[-1]
+        final_aum = portfolio_values['final_value']]
 
         self.assertAlmostEqual(
             final_aum,

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -1,5 +1,3 @@
-from market_object import MarketObject
-from portfolio import Portfolio
 import numpy as np
 def calculate_holdings(factor, aum, market):
     # Factor values for all tickers in the market
@@ -74,9 +72,9 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
             next_market = MarketObject(data.loc[data['Year'] == year + 1], year + 1)
             growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, next_market, market, verbosity)
 
-            if verbosity is not None and verbosity >= 2:
+            if verbosity >= 2:
                 print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, "
-                f"Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
+                      f"Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
 
             aum = total_end_value  # Liquidate and reinvest
 
@@ -90,7 +88,6 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
         years.append(year)
 
     if verbosity >= 1:
-:
         print("\n==== Final Summary ====")
         print(f"Initial Portfolio Value: ${initial_aum:.2f}")
         # Calculate overall growth

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -89,7 +89,8 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
 
         years.append(year)
 
-    if verbosity >= 1:
+    if if verbosity is not None and verbosity >= 1:
+:
         print("\n==== Final Summary ====")
         print(f"Initial Portfolio Value: ${initial_aum:.2f}")
         # Calculate overall growth

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -74,7 +74,8 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
             next_market = MarketObject(data.loc[data['Year'] == year + 1], year + 1)
             growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, next_market, market, verbosity)
 
-            if verbosity >= 2:
+            if verbosity is not None and verbosity >= 2:
+:
                 print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, "
                       f"Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
 

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -74,7 +74,7 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
             next_market = MarketObject(data.loc[data['Year'] == year + 1], year + 1)
             growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, next_market, market, verbosity)
 
-            if verbosity >= 2:
+            if verbosity is not None and verbosity >= 2:
                 print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, "
                       f"Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
 
@@ -89,7 +89,8 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
 
         years.append(year)
 
-    if verbosity >= 1:
+    if verbosity is not None and verbosity >= 1:
+
         print("\n==== Final Summary ====")
         print(f"Initial Portfolio Value: ${initial_aum:.2f}")
         # Calculate overall growth

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -75,9 +75,8 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
             growth, total_start_value, total_end_value = calculate_growth(yearly_portfolio, next_market, market, verbosity)
 
             if verbosity is not None and verbosity >= 2:
-:
                 print(f"Year {year} to {year + 1}: Growth: {growth:.2%}, "
-                      f"Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
+                f"Start Value: ${total_start_value:.2f}, End Value: ${total_end_value:.2f}")
 
             aum = total_end_value  # Liquidate and reinvest
 

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -1,3 +1,5 @@
+from market_object import MarketObject
+from portfolio import Portfolio
 import numpy as np
 def calculate_holdings(factor, aum, market):
     # Factor values for all tickers in the market

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -26,7 +26,7 @@ def calculate_holdings(factor, aum, market):
 
     return portfolio_new
 
-def calculate_growth(portfolio, next_market, current_market, verbosity=None):
+def calculate_growth(portfolio, next_market, current_market, verbosity=0):
     # Calculate start value using the current market
     total_start_value = 0
     for factor_portfolio in portfolio:
@@ -51,7 +51,7 @@ def calculate_growth(portfolio, next_market, current_market, verbosity=None):
     growth = (total_end_value - total_start_value) / total_start_value if total_start_value else 0
     return growth, total_start_value, total_end_value
 
-def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbosity=None):
+def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbosity=0):
     aum = initial_aum
     years = []
     portfolio_returns = []  # Store yearly returns for Information Ratio
@@ -128,7 +128,7 @@ def get_benchmark_return(year):
     }
     return benchmark_data.get(year, 0)
 
-def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity = None):
+def calculate_information_ratio(portfolio_returns, benchmark_returns, verbosity = 0):
     """
     Calculates the Information Ratio (IR) for a given set of portfolio returns and benchmark returns.
     

--- a/calculate_holdings.py
+++ b/calculate_holdings.py
@@ -89,7 +89,7 @@ def rebalance_portfolio(data, factors, start_year, end_year, initial_aum, verbos
 
         years.append(year)
 
-    if if verbosity is not None and verbosity >= 1:
+    if verbosity >= 1:
 :
         print("\n==== Final Summary ====")
         print(f"Initial Portfolio Value: ${initial_aum:.2f}")

--- a/fossil_fuel_restriction.py
+++ b/fossil_fuel_restriction.py
@@ -1,0 +1,8 @@
+def get_fossil_fuel_restriction():
+    response = input("\nRestrict fossil fuel companies? (Yes/No): ").strip().lower()
+    if response in ["yes", "y"]:
+        print("Fossil fuel restriction enabled.")
+        return True
+    else:
+        print("No fossil fuel restriction applied.")
+        return False

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from user_input import get_factors
 from verbosity_options import get_verbosity_level
 from fossil_fuel_restriction import get_fossil_fuel_restriction
 import pandas as pd
-
 def main():
     ### Load market data ###
     print("Loading market data...")
@@ -34,7 +33,7 @@ def main():
     rdata = rdata[['Ticker', 'Ending Price', 'Year'] + available_factors]
     factors = get_factors(available_factors)
     verbosity_level = get_verbosity_level() 
-    ### Rebaslancing portfolio across years ###
+    ### Rebalancing portfolio across years ###
     print("\nRebalancing portfolio...")
     
     rebalance_portfolio(rdata, factors, start_year=2002, end_year=2023, initial_aum=1,verbosity=verbosity_level)

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ def main():
             original_len = len(rdata)
             rdata = rdata[~rdata['FactSet Industry'].isin(excluded_industries)].copy()
             print(f"Filtered out {original_len - len(rdata)} fossil fuel-related companies.")
+            print(f"Fossil Fuel Keywords = ['oil', 'gas', 'coal', 'energy', 'fossil']")
         else:
             print("Warning: 'FactSet Industry' column not found. Cannot apply fossil fuel filter.")
 

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from market_object import load_data
 from calculate_holdings import rebalance_portfolio
 from user_input import get_factors
 from verbosity_options import get_verbosity_level
-from fossil_fuel_restriction import get_fossil_fuel_restriction()
+from fossil_fuel_restriction import get_fossil_fuel_restriction
 import pandas as pd
 
 def main():

--- a/main.py
+++ b/main.py
@@ -2,12 +2,28 @@ from market_object import load_data
 from calculate_holdings import rebalance_portfolio
 from user_input import get_factors
 from verbosity_options import get_verbosity_level
+from fossil_fuel_restriction import get_fossil_fuel_restriction()
 import pandas as pd
 
 def main():
     ### Load market data ###
     print("Loading market data...")
     rdata = load_data()
+    
+    ### Optional: Filter out fossil fuel-related industries ###
+    restrict_fossil_fuels = get_fossil_fuel_restriction()  # already defined in your code
+    if restrict_fossil_fuels:
+        excluded_industries = [
+            "Integrated Oil",
+            "Oilfield Services/Equipment",
+            "Oil & Gas Production"
+        ]
+        if 'FactSet Industry' in rdata.columns:
+            original_len = len(rdata)
+            rdata = rdata[~rdata['FactSet Industry'].isin(excluded_industries)].copy()
+            print(f"Filtered out {original_len - len(rdata)} fossil fuel-related companies.")
+        else:
+            print("Warning: 'FactSet Industry' column not found. Cannot apply fossil fuel filter.")
 
     ### Data preprocessing ###
     print("Processing market data...")
@@ -17,7 +33,7 @@ def main():
     rdata = rdata[['Ticker', 'Ending Price', 'Year'] + available_factors]
     factors = get_factors(available_factors)
     verbosity_level = get_verbosity_level() 
-    ### Rebalancing portfolio across years ###
+    ### Rebaslancing portfolio across years ###
     print("\nRebalancing portfolio...")
     
     rebalance_portfolio(rdata, factors, start_year=2002, end_year=2023, initial_aum=1,verbosity=verbosity_level)

--- a/market_object.py
+++ b/market_object.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 
 def load_data(restrict_fossil_fuels=False):
-    file_path = 'C:\\Users\\FM\'s Laptop\\Downloads\\College\\SYSEN 5900-669\\Financial Portfoilio\\Clean output\\FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
+    file_path = '/content/drive/My Drive/Cayuga Fund Factor Lake/FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
     rdata = pd.read_excel(file_path, sheet_name='Data', header=2, skiprows=[3, 4])
 
     rdata.columns = rdata.columns.str.strip()

--- a/market_object.py
+++ b/market_object.py
@@ -1,8 +1,26 @@
 import pandas as pd
 ### CREATING FUNCTION TO LOAD DATA ###
-def load_data():
-    file_path = '/content/drive/My Drive/Cayuga Fund Factor Lake/FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
+import numpy as np
+
+def load_data(restrict_fossil_fuels=False):
+    file_path = 'C:\\Users\\FM\'s Laptop\\Downloads\\College\\SYSEN 5900-669\\Financial Portfoilio\\Clean output\\FR2000 Annual Quant Data FOR RETURN SIMULATION.xlsx'
     rdata = pd.read_excel(file_path, sheet_name='Data', header=2, skiprows=[3, 4])
+
+    rdata.columns = rdata.columns.str.strip()
+
+    if 'Ticker' not in rdata.columns and 'Ticker-Region' in rdata.columns:
+        rdata['Ticker'] = rdata['Ticker-Region'].dropna().apply(lambda x: x.split('-')[0].strip())
+
+    if restrict_fossil_fuels:
+        industry_col = 'FactSet Industry'
+        if industry_col in rdata.columns:
+            rdata[industry_col] = rdata[industry_col].astype(str).str.lower()
+            fossil_keywords = ['oil', 'gas', 'coal', 'energy', 'fossil']
+            mask = rdata[industry_col].apply(lambda x: not any(kw in x for kw in fossil_keywords))
+            rdata = rdata[mask]
+        else:
+            print("Warning: 'FactSet Industry' column not found. Fossil fuel filtering skipped.")
+
     return rdata
 
 class MarketObject():


### PR DESCRIPTION
### Sector Restriction with Fossil Fuel Filtering
As part of the portfolio construction process, this implements a sector restriction feature that allows users to exclude companies involved in fossil fuel-related industries. To achieve this, the industry descriptions associated with each company was utilized.

The defined list of fossil fuel keywords are: 
**Fossil Fuel Keywords = ['oil', 'gas', 'coal', 'energy', 'fossil']**

The code scans the industry fields for any of these keywords. If a company matches any of them, it is excluded from the portfolio. This enables users to avoid exposure to companies engaged in fossil fuel production or distribution.

